### PR TITLE
change workspacePath of commit cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
-# Git Quick Commit
+forked from [yoko0180/vscode-git-quick-commit](https://github.com/yoko0180/vscode-git-quick-commit)
 
-Quick commit with select text.
-
-![rules hovers](./images/demo.gif)
-
-**Enjoy!**
+### Changes
+1. Support multi folders in a window
+2. Support autoPush after commit by config `vscode-git-quick-commit-v2.autoPush: true`

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "vscode-git-quick-commit",
-	"displayName": "Git Quick Commit",
+	"name": "vscode-git-quick-commit-v2",
+	"displayName": "Git Quick Commit v2",
 	"description": "Quick commit with select text",
 	"version": "0.0.1",
 	"license": "MIT",
-  "publisher": "yoko0180",
+	"publisher": "yzpTsubasa",
 	"engines": {
 		"vscode": "^1.45.0"
 	},
@@ -12,36 +12,36 @@
 		"Other"
 	],
 	"keywords": [
-    "git",
-    "commit",
-    "quick"
+		"git",
+		"commit",
+		"quick"
 	],
 	"icon": "images/icon.png",
 	"repository": {
-    "type": "git",
-    "url": "https://github.com/yoko0180/vscode-git-quick-commit.git"
-  },
+		"type": "git",
+		"url": "https://github.com/yzpTsubasa/vscode-git-quick-commit.git"
+	},
 	"activationEvents": [
-        "onCommand:vscode-git-quick-commit.selectionCommentGitCommit"
+		"onCommand:vscode-git-quick-commit.selectionCommentGitCommit"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
 		"menus": {
 			"editor/title": [
-			 {
-				"when": "editorTextFocus",
-				"command": "vscode-git-quick-commit.selectionCommentGitCommit",
-				"group": "navigation@1"
-			 }
+				{
+					"when": "editorTextFocus",
+					"command": "vscode-git-quick-commit.selectionCommentGitCommit",
+					"group": "navigation@1"
+				}
 			]
-		 },
+		},
 		"commands": [
 			{
 				"command": "vscode-git-quick-commit.selectionCommentGitCommit",
-        "title": "Selection Comment Git Commit: Quick Commit",
+				"title": "Selection Comment Git Commit: Quick Commit",
 				"icon": {
-				 "light": "images/rocket.svg",
-				 "dark": "images/rocket.svg"
+					"light": "images/rocket.svg",
+					"dark": "images/rocket.svg"
 				}
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Quick commit with select text",
 	"version": "0.0.1",
 	"license": "MIT",
-	"publisher": "yzpTsubasa",
+	"publisher": "TsubasaYeung",
 	"engines": {
 		"vscode": "^1.45.0"
 	},

--- a/src/lib/selectionCommentGitCommit.ts
+++ b/src/lib/selectionCommentGitCommit.ts
@@ -29,10 +29,23 @@ export default async (options: any): Promise<string> => {
 
   vscode.workspace.saveAll();
 
-  if (!vscode.workspace.rootPath) {
-    throw new Error('ワークスペースルートパスが不明です。');
-  }
+  // if (!vscode.workspace.rootPath) {
+  //   throw new Error('ワークスペースルートパスが不明です。');
+  // }
 
-  let cmd = `git add . && git commit -m"${input}"`;
-  return exec(cmd, {cwd: vscode.workspace.rootPath}).then( () => cmd);
+  let commitCmd = `git add . && git commit -m"${input}"`;
+  let pushCmd = `git push`;
+  let workspaceFoler = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+  let workspacePath = workspaceFoler && workspaceFoler.uri.fsPath;
+  if (!workspacePath) {
+    throw new Error("workspacePathが不明です。");
+  }
+  return exec(commitCmd, {cwd: workspacePath})
+  .then( () => {
+    exec(pushCmd, {cwd: workspacePath})
+  })
+  .catch((err: Error) => {
+    throw err;
+  })
+  ;
 };


### PR DESCRIPTION
これは素晴らしいエクステンションです、ありがとう。
`src\lib\selectionCommentGitCommit.ts` ファイルの`exec`実行ディレクトリ`cwd`は`vscode.workspace.rootPath`です。
この状況は、エディターに項目が1つしかない場合に正常に実行できます。 ただし、エディターに複数のプロジェクトがある場合、`vscode.workspace.rootPath`は現在のファイルの正しい作業ディレクトリを取得できません。
`vscode.workspace.rootPath`を次の`workspacePath`に置き換える必要があると思います
```
let workspaceFoler = vscode.workspace.getWorkspaceFolder(editor.document.uri);
let workspacePath = workspaceFoler && workspaceFoler.uri.fsPath;
```
そしてまた、コミット[commit]が成功した直後にプッシュ[push]するか、同期[sync]を実行するかを選択することもできれば、より完全になります。